### PR TITLE
Lifesteal Arrow Type

### DIFF
--- a/Assets/Scripts/Arrows/ArrowController.cs
+++ b/Assets/Scripts/Arrows/ArrowController.cs
@@ -182,9 +182,15 @@ namespace Assets.Scripts.Arrows
                     return gameObject.AddComponent<GhostArrow>();
                 case Enums.Arrows.Gravity:
                     return gameObject.AddComponent<GravityArrow>();
+				case Enums.Arrows.Lifesteal:
+					return gameObject.AddComponent<LifestealArrow>();
                 default:
                     return gameObject.AddComponent<NormalArrow>();
             }
         }
+
+		public float GetDamage() {
+			return damage;
+		}
     }
 }

--- a/Assets/Scripts/Arrows/LifestealArrow.cs
+++ b/Assets/Scripts/Arrows/LifestealArrow.cs
@@ -1,0 +1,23 @@
+﻿using UnityEngine;
+
+namespace Assets.Scripts.Arrows
+{
+	/// <summary>
+	/// Arrow property that gives life to the player who shot it when it hits another player.
+	/// </summary>
+	public class LifestealArrow : ArrowProperty
+	{
+
+		public override void Effect(PlayerID hitPlayer)
+		{
+			// If a player was hit
+			if (hitPlayer != 0)
+			{
+				Player.Controller sourceController = Data.GameManager.instance.GetPlayer(fromPlayer);
+				float damage = GetComponent<ArrowController>().GetDamage();
+				sourceController.LifeComponent.ModifyHealth(damage);
+			}
+		}
+	}
+}
+

--- a/Assets/Scripts/Util/Enums.cs
+++ b/Assets/Scripts/Util/Enums.cs
@@ -5,8 +5,8 @@
     /// </summary>
     public static class Enums
     {
-        public enum Arrows { Normal, Fireball, Ice, Thunder, Acid, Ricochet, Ghost, Gravity, NumTypes };
-        public enum Tokens { Fireball, Ice, Thunder, Acid, Ricochet, Ghost, Gravity, Health, NumTypes };
+        public enum Arrows { Normal, Fireball, Ice, Thunder, Acid, Ricochet, Ghost, Gravity, Lifesteal, NumTypes };
+        public enum Tokens { Fireball, Ice, Thunder, Acid, Ricochet, Ghost, Gravity, Lifesteal, Health, NumTypes };
         public enum GameType { Stock, Kills, Target };
         public enum RepetitionTimerSettings { Limited, Unlimited };
         public enum Frequency { None, Sparce, Infrequent, Average, Frequent, Abundant, NumTypes };


### PR DESCRIPTION
Adds a new type of arrow, which heals the player who shot it when it hits another player.
