### PR TITLE
Fix Main Menu Bug - NRE

### DIFF
--- a/Assets/Scripts/UI/MenuManager.cs
+++ b/Assets/Scripts/UI/MenuManager.cs
@@ -489,7 +489,7 @@ namespace Assets.Scripts.UI
                 panel.SetAsLastSibling();
             }
             GameObject defaultButton = panel.GetComponent<MenuOption>().DefaultButton;
-            if (defaultButton)
+            if (defaultButton != null && EventSystem.current !=  null)
             {
                 EventSystem.current.SetSelectedGameObject(defaultButton);
                 Navigator.defaultGameObject = defaultButton;


### PR DESCRIPTION
fixed another null check while I was at it.

This issue might be from a weird unity install/device specific. But more null checks on launch can't hurt.
